### PR TITLE
Re-enable averaging in SHFQA scope mode

### DIFF
--- a/src/zhinst/utils/shfqa/shfqa.py
+++ b/src/zhinst/utils/shfqa/shfqa.py
@@ -119,7 +119,7 @@ def get_scope_settings(
     settings = [
         (scope_path + "segments/count", num_segments),
         (scope_path + "segments/enable", 1 if num_segments > 1 else 0),
-        (scope_path + "averaging/enable", 1 if num_segments > 1 else 0),
+        (scope_path + "averaging/enable", 1 if num_averages > 1 else 0),
         (scope_path + "averaging/count", num_averages),
         (scope_path + "channels/*/enable", 0),
     ]


### PR DESCRIPTION
Correct a typo introduced in 9dfd57d so that scope mode averaging is enabled if `num_averages > 1` rather than if `num_segments > 1`

Tested to work with an actual SHFQA, LabOne 23.06.